### PR TITLE
REQ-17177 remove optional argument

### DIFF
--- a/src/Elasticsearch/Transport.php
+++ b/src/Elasticsearch/Transport.php
@@ -48,7 +48,7 @@ class Transport
      * @param ConnectionPool\AbstractConnectionPool $connectionPool
      * @param \Psr\Log\LoggerInterface $log    Monolog logger object
      */
-    public function __construct($retries, $sniffOnStart = false, AbstractConnectionPool $connectionPool, LoggerInterface $log)
+    public function __construct($retries, $sniffOnStart, AbstractConnectionPool $connectionPool, LoggerInterface $log)
     {
         $this->log            = $log;
         $this->connectionPool = $connectionPool;


### PR DESCRIPTION
Assuming the Transport object [is instantiated only by the ClientBuilder](https://github.com/zumba/elasticsearch-php/blob/support-php8/src/Elasticsearch/ClientBuilder.php#L590), this solution should be valid.